### PR TITLE
fix for https://github.com/flipbyte/yup-schema/issues/8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /node_modules
 /umd
 npm-debug.log*
+/.idea

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,8 @@ export default class Rules {
 
     processArgs(args) {
         return args.reduce((result, arg) => {
-            if (typeof arg === 'object' && arg.constructor === Object && !Array.isArray(arg)) {
+            // test for arg !== null, because typeof null === "object", but null.constructor is Uncaught TypeError
+            if (arg !== null && typeof arg === 'object' && arg.constructor === Object && !Array.isArray(arg)) {
                 return [ ...result, this.handleObject(arg)];
             } else if (this.isRule(arg)) {
                 return [ ...result, new Rules(arg).toYup()];

--- a/tests/object.test.js
+++ b/tests/object.test.js
@@ -512,6 +512,21 @@ describe('Object types', () => {
         ]);
     });
 
+    it('should handle default null for object', () => {
+        let inst = new Rules([
+            ['object', {
+                other: [
+                    ['bool']
+                ]
+            }],
+            ['default', null]
+        ]).toYup()
+
+        expect(inst.concat(new Rules([
+            ['object']
+        ]).toYup()).default()).to.equal(null);
+    })
+
     it('should work with noUnknown', () => {
         let inst = new Rules([
             ['object', {


### PR DESCRIPTION
if we set a default, null, then we get a Uncaught TypeError: Cannot read property 'constructor' of null

//test for arg !== null, because typeof null === "object", but null.constructor is Uncaught TypeError

this allows us to have ["default", null]